### PR TITLE
Story 5536/metabase db backups

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ set -eu
 
 METABASE_DIR="$1/target/uberjar"
 METABASE_JAR="$METABASE_DIR/metabase.jar"
-METABASE_URL="https://downloads.metabase.com/enterprise/latest/metabase.jar"
+METABASE_URL="https://downloads.metabase.com/enterprise/v1.44.5/metabase.jar"
 
 mkdir -p $METABASE_DIR
 

--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,14 @@ METABASE_DIR="$1/target/uberjar"
 METABASE_JAR="$METABASE_DIR/metabase.jar"
 METABASE_URL="https://downloads.metabase.com/enterprise/v1.44.5/metabase.jar"
 
+BUIILDPACK_BIN="$PWD/bin"
+APP_BIN="$1/bin"
+BACKUP_SCRIPT="pg_backup_to_s3"
+
+echo "Copying pg_backup_to_s3 to $APP_BIN"
+cp "$BUIILDPACK_BIN/$BACKUP_SCRIPT" "$APP_BIN/$BACKUP_SCRIPT"
+chmod +x "$APP_BIN/$BACKUP_SCRIPT"
+
 mkdir -p $METABASE_DIR
 
 echo -n "-----> Downloading Metabase... from $METABASE_URL to $METABASE_JAR"

--- a/bin/pg_backup_to_s3
+++ b/bin/pg_backup_to_s3
@@ -1,0 +1,26 @@
+# Set the script to fail fast if there
+# is an error or a missing variable
+
+set -eu
+set -o pipefail
+
+#!/bin/sh
+
+# Get db dump from heroku
+pg_dump -F c --no-acl --no-owner --quote-all-identifiers $DATABASE_URL > tmp/pg_backup.dump
+
+# Encrypt backup file using GPG passphrase
+gpg --yes --batch --passphrase=$PG_BACKUP_PASSWORD -c tmp/pg_backup.dump
+
+# Remove the plaintext backup file
+rm tmp/pg_backup.dump
+
+# Generate backup filename based
+# on the current date
+BACKUP_FILE_NAME="backup-$(date '+%Y-%m-%d_%H.%M').gpg"
+
+# Upload the file to S3 using AWS CLI
+aws s3 cp tmp/pg_backup.dump.gpg "s3://${PG_BACKUP_S3_BUCKET_NAME}/${BACKUP_FILE_NAME}"
+
+# Remove the encrypted backup file
+rm tmp/pg_backup.dump.gpg


### PR DESCRIPTION
[Shortcut](https://app.shortcut.com/phpdev/story/5536/metabase-backups)

**Description:**
This PR adds to `compile` to add the script to send an encrypted dump of the Metabase db to a S3 Bucket

Notes:
- The script requires the AWS buildback
- The following config vars are also required:
  - DATABASE_URL
  - PG_BACKUP_S3_BUCKET_NAME
(Below from either staging or prod app configs)
  - AWS_DEFAULT_REGION
  - S3_BUCKET_NAME
  - AWS_SECRET_ACCESS_KEY
  - AWS_ACCESS_KEY_ID 