### PR TITLE
Add creation of tmp directory for backups

### DIFF
--- a/bin/pg_backup_to_s3
+++ b/bin/pg_backup_to_s3
@@ -6,6 +6,9 @@ set -o pipefail
 
 #!/bin/sh
 
+# Create tmp directory if does not exist
+mkdir -p tmp
+
 # Get db dump from heroku
 pg_dump -F c --no-acl --no-owner --quote-all-identifiers $DATABASE_URL > tmp/pg_backup.dump
 


### PR DESCRIPTION
[Shortcut](https://app.shortcut.com/phpdev/story/5536/metabase-backups)

**Description:**
This Ensures a `tmp` directory exists for the `pg_backup_to_s3` script to create pg_dump processing.