### PR TITLE
Set metabase download url to version v1.45.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ set -eu
 
 METABASE_DIR="$1/target/uberjar"
 METABASE_JAR="$METABASE_DIR/metabase.jar"
-METABASE_URL="https://downloads.metabase.com/enterprise/v1.44.5/metabase.jar"
+METABASE_URL="https://downloads.metabase.com/enterprise/v1.45.1/metabase.jar"
 
 BUIILDPACK_BIN="$PWD/bin"
 APP_BIN="$1/bin"


### PR DESCRIPTION
[Shortcut](https://app.shortcut.com/phpdev/story/5728/bump-staging-metabase-version-to-new-fix-version)

Update buildpack to download Metabase v1.45.1