### PR TITLE
Set metabase download url to latest version 1.46.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ set -eu
 
 METABASE_DIR="$1/target/uberjar"
 METABASE_JAR="$METABASE_DIR/metabase.jar"
-METABASE_URL="https://downloads.metabase.com/enterprise/v1.45.1/metabase.jar"
+METABASE_URL="https://downloads.metabase.com/enterprise/latest/metabase.jar"
 
 BUIILDPACK_BIN="$PWD/bin"
 APP_BIN="$1/bin"

--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ set -eu
 
 METABASE_DIR="$1/target/uberjar"
 METABASE_JAR="$METABASE_DIR/metabase.jar"
-METABASE_URL="https://downloads.metabase.com/enterprise/latest/metabase.jar"
+METABASE_URL="https://downloads.metabase.com/enterprise/v1.46.1/metabase.jar"
 
 BUIILDPACK_BIN="$PWD/bin"
 APP_BIN="$1/bin"


### PR DESCRIPTION
[Shortcut](https://app.shortcut.com/phpdev/story/5728/bump-staging-metabase-version-to-new-fix-version)

Update buildpack to download latest Metabase, v1.46.1