### PR TITLE
Update to v1.47.13

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ set -eu
 
 METABASE_DIR="$1/target/uberjar"
 METABASE_JAR="$METABASE_DIR/metabase.jar"
-METABASE_URL="https://downloads.metabase.com/enterprise/v1.47.0/metabase.jar"
+METABASE_URL="https://downloads.metabase.com/enterprise/v1.47.13/metabase.jar"
 
 
 BUIILDPACK_BIN="$PWD/bin"


### PR DESCRIPTION
https://app.shortcut.com/phpdev/story/7036/upgrade-metabase-staging

Note: story says 1.47.12, but at time of update, last patch version before v1.48 was v1.47.13.

https://github.com/metabase/metabase/releases/tag/v1.47.13